### PR TITLE
Expose plugin config to webapp

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,10 @@
 {
-    "id": "com.mattermost.plugin-starter-template",
-    "name": "Plugin Starter Template",
-    "description": "This plugin serves as a starting point for writing a Mattermost plugin.",
-    "homepage_url": "https://github.com/mattermost/mattermost-plugin-starter-template",
-    "support_url": "https://github.com/mattermost/mattermost-plugin-starter-template/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-starter-template/releases/tag/v0.1.0",
+    "id": "webapp-config-example",
+    "name": "Webapp Config Example",
+    "description": "This plugin serves as an example showing how to share plugin config values with a webapp plugin.",
+    "homepage_url": "https://github.com/mickmister/mattermost-plugin-webapp-config",
+    "support_url": "https://github.com/mickmister/mattermost-plugin-webapp-config/issues",
+    "release_notes_url": "https://github.com/mickmister/mattermost-plugin-webapp-config/releases/tag/v0.1.0",
     "icon_path": "assets/starter-template-icon.svg",
     "version": "0.1.0",
     "min_server_version": "5.12.0",
@@ -22,6 +22,14 @@
     "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [
+            {
+                "key": "TheSetting",
+                "display_name": "Setting to fetch from the plugin",
+                "type": "text",
+                "help_text": "",
+                "default": ""
+            }
+        ]
     }
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server
@@ -18,6 +20,7 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
+	TheSetting string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
@@ -70,14 +73,23 @@ func (p *Plugin) setConfiguration(configuration *configuration) {
 
 // OnConfigurationChange is invoked when configuration changes may have been made.
 func (p *Plugin) OnConfigurationChange() error {
-	var configuration = new(configuration)
+	oldConfig := p.getConfiguration()
+	newConfig := new(configuration)
 
 	// Load the public configuration fields from the Mattermost server configuration.
-	if err := p.API.LoadPluginConfiguration(configuration); err != nil {
+	if err := p.API.LoadPluginConfiguration(newConfig); err != nil {
 		return errors.Wrap(err, "failed to load plugin configuration")
 	}
 
-	p.setConfiguration(configuration)
+	p.setConfiguration(newConfig)
+
+	if oldConfig.TheSetting != newConfig.TheSetting {
+		// in case we want to include the config values in the websocket message itself
+		payload := map[string]interface{}{
+			"the_setting": newConfig.TheSetting,
+		}
+		p.API.PublishWebSocketEvent("setting_changed", payload, &model.WebsocketBroadcast{})
+	}
 
 	return nil
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync"
@@ -22,7 +23,22 @@ type Plugin struct {
 
 // ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "Hello, world!")
+	switch r.URL.Path {
+	case "/config":
+		config := p.getConfiguration()
+
+		// be sure not to include the whole config if there are sensitive plugin config values
+		b, err := json.Marshal(config)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "error marshaling config %v", err)
+			return
+		}
+
+		w.Write(b)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
 }
 
 // See https://developers.mattermost.com/extend/plugins/server/reference/

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1,6 +1,7 @@
 import {Store, Action} from 'redux';
 
 import {GlobalState} from 'mattermost-redux/types/store';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import manifest from './manifest';
 
@@ -10,7 +11,24 @@ import {PluginRegistry} from './types/mattermost-webapp';
 export default class Plugin {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
     public async initialize(registry: PluginRegistry, store: Store<GlobalState, Action<Record<string, unknown>>>) {
-        // @see https://developers.mattermost.com/extend/plugins/webapp/reference/
+        const state = store.getState();
+        const config = getConfig(state);
+        const siteURL = config.SiteURL;
+
+        const endpoint = `${siteURL}/plugins/${manifest.id}/config`;
+        fetch(endpoint).then((r) => r.json()).then((data) => {
+            // Note that you should store the result in redux for later use.
+            const message = `Plugin received config through API: ${JSON.stringify(data)}`;
+            alert(message);
+        });
+
+        const websocketEventName = 'setting_changed';
+        const fullEventName = `custom_${manifest.id}_${websocketEventName}`;
+        registry.registerWebSocketEventHandler(fullEventName, (event) => {
+            // Update the config value in redux at this time.
+            const message = `Plugin received config through websockets: ${JSON.stringify(event.data)}`;
+            alert(message);
+        });
     }
 }
 


### PR DESCRIPTION
This PR is meant to show how a plugin can expose its config settings to the webapp portion of the plugin. In this example, the config values are also sent to the client when the settings are changed. Note that the webapp plugin should store these values in redux for later use, though this example does not store the values.

Read the comments below for known issues.